### PR TITLE
Skip actions that cannot be parsed when reading outline

### DIFF
--- a/src/com/sun/pdfview/PDFFile.java
+++ b/src/com/sun/pdfview/PDFFile.java
@@ -1422,7 +1422,12 @@ public class PDFFile {
 
                 PDFObject actionObj = scan.getDictRef("A");
                 if (actionObj != null) {
-                    action = PDFAction.getAction(actionObj, getRoot());
+                    try {
+                        action = PDFAction.getAction(actionObj, getRoot());
+                    }
+                    catch (PDFParseException e) {
+                    	// oh well
+                    }
                 } else {
                     // try to create an action from a destination
                     PDFObject destObj = scan.getDictRef("Dest");


### PR DESCRIPTION
If the action cannot be parsed for some reason (for example a corrupt PDF file), skip it. This is parallel to what is already done in the else part when reading the destination.
