### PR TITLE
Don't bail on empty pdf content

### DIFF
--- a/src/com/sun/pdfview/PDFFile.java
+++ b/src/com/sun/pdfview/PDFFile.java
@@ -1624,7 +1624,7 @@ public class PDFFile {
         // concatenate all the streams
         PDFObject contentsObj = pageObj.getDictRef("Contents");
         if (contentsObj == null) {
-            throw new IOException("No page contents!");
+            return new byte[0];
         }
 
         PDFObject contents[] = contentsObj.getArray();


### PR DESCRIPTION
Contents can be empty - don't return null page
