### PR TITLE
Unsupported shader

### DIFF
--- a/src/com/sun/pdfview/font/ttf/CmapTable.java
+++ b/src/com/sun/pdfview/font/ttf/CmapTable.java
@@ -19,6 +19,7 @@
 package com.sun.pdfview.font.ttf;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -72,7 +73,23 @@ public class CmapTable extends TrueTypeTable {
      * Get all CMaps
      */
     public CMap[] getCMaps() {
-        Collection<CMap> c = this.subtables.values();
+        Collection<CMap> c = new ArrayList<CMap>();
+        
+        CMap cmap_3_1 = this.getCMap((short)3, (short)1);
+        if (cmap_3_1 != null) {
+        	c.add(cmap_3_1);
+        }
+        CMap cmap_1_0 = this.getCMap((short)1, (short)0);
+        if (cmap_1_0 != null) {
+        	c.add(cmap_1_0);
+        }
+
+        for (CMap cmap : this.subtables.values()) {
+        	if (!c.contains(cmap)) {
+        		c.add(cmap);
+        	}
+        }
+                ;
         CMap[] maps = new CMap[c.size()];
         
         c.toArray(maps);

--- a/src/com/sun/pdfview/pattern/DummyShader.java
+++ b/src/com/sun/pdfview/pattern/DummyShader.java
@@ -1,0 +1,25 @@
+package com.sun.pdfview.pattern;
+
+import java.awt.Color;
+import java.io.IOException;
+
+import com.sun.pdfview.PDFObject;
+import com.sun.pdfview.PDFPaint;
+
+public class DummyShader extends PDFShader {
+
+	protected DummyShader(int type) {
+		super(type);
+	}
+
+	@Override
+	public void parse(PDFObject shareObj) throws IOException {
+		
+	}
+
+	@Override
+	public PDFPaint getPaint() {
+		return PDFPaint.getPaint(Color.PINK);
+	}
+		
+}

--- a/src/com/sun/pdfview/pattern/PDFShader.java
+++ b/src/com/sun/pdfview/pattern/PDFShader.java
@@ -136,7 +136,7 @@ public abstract class PDFShader {
             case COONS_PATCH_MESH_SHADING:
             case TENSOR_PRODUCTS_MESH_SHADING:
             default:    
-                throw new PDFParseException("Unsupported shader type: " + type);
+            		shader = new DummyShader(type);
         }
         
         // read the color space (required)


### PR DESCRIPTION
Issue #39.
Workaround: when the shader type is not supported, return a dummy Shader
with color PINK
The picture is displayed even if it has the wrong color

Please ignore the comit on CmapTable