### PR TITLE
for page rotation use only multiples of 90 degrees

### DIFF
--- a/src/com/sun/pdfview/PDFPage.java
+++ b/src/com/sun/pdfview/PDFPage.java
@@ -93,9 +93,12 @@ public class PDFPage {
         if (bbox == null) {
             bbox = new Rectangle2D.Float(0, 0, 1, 1);
         }
+        rotation = rotation % 360; // less than a full turn
         if (rotation < 0) {
             rotation += 360;
         }
+        rotation = rotation / 90; // for page rotation use only multiples of 90 degrees 
+        rotation = rotation * 90; // 0, 90, 180, 270
         this.rotation = rotation;
         if (rotation == 90 || rotation == 270) {
             bbox = new Rectangle2D.Double(bbox.getX(), bbox.getY(), bbox.getHeight(), bbox.getWidth());


### PR DESCRIPTION
, other values caused a mirrored page