### PR TITLE
[PDF_RENDERER-144] FIX Type 2 functions

### DIFF
--- a/src/com/sun/pdfview/function/FunctionType2.java
+++ b/src/com/sun/pdfview/function/FunctionType2.java
@@ -99,6 +99,13 @@ public class FunctionType2 extends PDFFunction {
         }
     }
     
+    @Override
+    public int getNumOutputs()
+    {
+        // For Type 2 functions, the number of outputs is determined by the size of C0 (or C1).
+        return c0.length;
+    }
+    
     /**
      * Get the exponent
      */


### PR DESCRIPTION
The issue https://java.net/jira/browse/PDF_RENDERER-144 addresses handling of Type 2 patterns. In this fork, support for Type 2 patterns is already available. However, a small fix is still required to display gradients correctly:

For Type 2 (Exponential Interpolation) functions, the Range parameter is optional. Therefore, the number of outputs shall be determined by the size of C0 (or C1).

For more details, see PDF Reference, Sixth Edition, version 1.7, section 3.9.2.

For testing, use the [test PDF file](https://java.net/jira/secure/attachment/49547/gradient.pdf) from the mentioned issue.