### PR TITLE
[PDF_RENDERER-145] FIX conditionally required font dictionary properties

### DIFF
--- a/src/com/sun/pdfview/font/PDFFont.java
+++ b/src/com/sun/pdfview/font/PDFFont.java
@@ -151,7 +151,7 @@ public abstract class PDFFont {
         }
 
         if (descObj != null) {
-            descriptor = new PDFFontDescriptor(descObj);
+            descriptor = new PDFFontDescriptor(descObj, subType);
         } else {
             descriptor = new PDFFontDescriptor(baseFont);
         }


### PR DESCRIPTION
For Type 3 fonts, some font descriptor properties are optional that are required for all other font types. This should be taken into account when parsing a font descriptor.

For more details, see PDF Reference, Sixth Edition, version 1.7, section 5.7.

Additionally, I encountered a [PDF](https://github.com/katjas/PDFrenderer/files/749822/NoStemV.pdf) where one of these parameters is also missing for a TrueType font. Therefore, a system property for lenient font descriptor parsing was introduced to allow rendering of this PDF as well.