### PR TITLE
Patch 2

### DIFF
--- a/src/com/sun/pdfview/PDFFile.java
+++ b/src/com/sun/pdfview/PDFFile.java
@@ -870,7 +870,7 @@ public class PDFFile {
                 break;      // out-of-range, should have been hex
             }
             // H.3.2.4 indicates version 1.1 did not do hex escapes
-            if (c == '#' && (this.majorVersion != 1 && this.minorVersion != 1)) {
+            if (c == '#' && (this.majorVersion >= 1 && this.minorVersion > 1)) {
                 int hex = readHexPair();
                 if (hex >= 0) {
                     c = hex;

--- a/src/com/sun/pdfview/font/CIDFontType0.java
+++ b/src/com/sun/pdfview/font/CIDFontType0.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import com.sun.pdfview.PDFObject;
 import com.sun.pdfview.font.cid.PDFCMap;
+import com.sun.pdfview.font.ttf.AdobeGlyphList;
 
 /*****************************************************************************
  * At the moment this is not fully supported to parse CID based fonts
@@ -56,6 +57,11 @@ public class CIDFontType0 extends BuiltinFont {
     	// See "9.10 Extraction of Text Content" in the PDF spec.
         if (this.glyphLookupMap != null) {
         	src = this.glyphLookupMap.map(src);
+            //The preferred method of getting the glyph should be by name. 
+            if (name == null && src != 160){//unless it NBSP
+            	//so, try to find the name by the char
+            	name = AdobeGlyphList.getGlyphName(src);
+            }
         }
 		return super.getGlyph(src, name);
     }

--- a/src/com/sun/pdfview/font/PDFFont.java
+++ b/src/com/sun/pdfview/font/PDFFont.java
@@ -212,7 +212,8 @@ public abstract class PDFFont {
                 font = new CIDFontType2(baseFont, obj, descriptor);
         	}else {
                 // fake it with a built-in font
-                font = new BuiltinFont(baseFont, obj, descriptor);
+       		//but it prefer to use the CIDFontType0 that have the extra handling of ToUnicode, if found in the fontObj
+	                font = new CIDFontType0(baseFont, obj, descriptor);
         	}
         } else if (subType.equals("CIDFontType0")) {
         	if(descriptor.getFontFile2() !=null){

--- a/src/com/sun/pdfview/font/PDFFontDescriptor.java
+++ b/src/com/sun/pdfview/font/PDFFontDescriptor.java
@@ -103,7 +103,12 @@ public class PDFFontDescriptor {
     public PDFFontDescriptor(PDFObject obj, String fontSubType) throws IOException {
         // required parameters
         setFlags(obj.getDictRef("Flags").getIntValue());
-        setFontName(obj.getDictRef("FontName").getStringValue());
+        PDFObject fontNameObj = obj.getDictRef("FontName");
+        if (fontNameObj == null){
+        	// fallback to avoid NPE try to use the BaseFont
+        	fontNameObj = obj.getDictRef("BaseFont");
+        }
+        setFontName(fontNameObj.getStringValue());
         setItalicAngle(obj.getDictRef("ItalicAngle").getIntValue());
         
         // conditionally required parameters


### PR DESCRIPTION
fixing PDF with "CIDFontType2" font failed to renderer due to NPE since the "FontName" is null #73
https://github.com/katjas/PDFrenderer/issues/73