### PR TITLE
fix blank page presented in case there is space after commented line

### DIFF
--- a/src/com/sun/pdfview/PDFParser.java
+++ b/src/com/sun/pdfview/PDFParser.java
@@ -211,6 +211,10 @@ public class PDFParser extends BaseWatchable {
                 if (c == '\r') {
                     c = this.stream[this.loc++]; // eat a following return
                 }
+                // skip whitespace
+                while (this.loc < this.stream.length && PDFFile.isWhiteSpace(c)) {
+                	c = this.stream[this.loc++];
+                }
             }
             PDFDebugger.debug("Read comment: " + comment.toString(), -1);
         }


### PR DESCRIPTION
exam for spaces after commented line and skip them
this fixing issue: #79