### PR TITLE
Ignore empty graphic state

### DIFF
--- a/src/com/sun/pdfview/PDFParser.java
+++ b/src/com/sun/pdfview/PDFParser.java
@@ -1276,6 +1276,9 @@ public class PDFParser extends BaseWatchable {
         // TODO: lots of graphic states are not yet considered, see chapter 8.4.5 of the PDF specification.  
         // get LW, LC, LJ, Font, SM, CA, ML, D, RI, FL, BM, ca
         // out of the reference, which is a dictionary
+        if (gsobj == null) {
+            return;
+        }
         PDFObject d;
         boolean handled = false;
         if ((d = gsobj.getDictRef("LW")) != null) {


### PR DESCRIPTION
I have an application that produces PDFs with an empty Graphic State (/Resources<</ExtGState<<>>).
Without the change in this commit PDFrenderer creates a blank image and logs a NPE in background, with the change it creates the desired result.
I'm no PDF expert, but all mainstream PDF readers were able to open the files correctly with the empty Graphic State.